### PR TITLE
removed generating constants from setup.py file.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,26 +1,5 @@
-from distutils.command.build import build as _build
-from distutils.command.clean import clean as _clean
 from distutils.core import setup
-
-import os
-
-import genconstants
-
 from version import VERSION
-
-class clean(_clean):
-    def run(self):
-        if os.path.exists('/usr/include/net-snmp/library/snmp_api.h'):
-            for filename in "CONSTANTS.py", "CONSTANTS.pyc":
-                if os.path.exists(filename):
-                    os.remove(filename)
-                _clean.run(self)
-
-class build(_build):
-    def run(self):
-        if os.path.exists('/usr/include/net-snmp/library/snmp_api.h'):
-            genconstants.make_imports()
-            _build.run(self)
 
 if __name__=='__main__':
     setup(name='pynetsnmp',
@@ -28,7 +7,6 @@ if __name__=='__main__':
           description='ctypes wrapper for net-snmp',
           author='Eric C. Newton',
           author_email='ecn@zenoss.com',
-          cmdclass={'build': build, 'clean' : clean},
           package_dir = {'pynetsnmp':'.',},
           packages = ['pynetsnmp',],
           )


### PR DESCRIPTION
Hello, when i am trying to setup pynetsnmp module i am getting thoose errors:
ERROR:zen.genconstants:Invalid python statement: snmp_increment_statistic = (X), name 'X' is not defined
ERROR:zen.genconstants:Invalid python statement: snmp_increment_statistic_by = (X,Y), name 'X' is not defined
ERROR:zen.genconstants:Invalid python statement: NETSNMP_NO_SUCH_PROCESS = INVALID_HANDLE_VALUE, name 'INVALID_HANDLE_VALUE' is not defined

I tried to fix regular expression in genconstants.py file but i got differrent errors after that. So, i think it would be better to disable genrating constants module