### PR TITLE
Don't modify timeout in SnmpSession.

### DIFF
--- a/pynetsnmp/SnmpSession.py
+++ b/pynetsnmp/SnmpSession.py
@@ -24,7 +24,7 @@ class SnmpSession(object):
         "Synchronous get implementation"
         self.session = netsnmp.Session(
             version=self._version,
-            timeout=int(self.timeout*1e6),
+            timeout=self.timeout,
             retries=int(self.retries-1),
             peername= '%s:%d' % (self.ip, self.port),
             community=self.community,


### PR DESCRIPTION
The conversion to microseconds occurs later.

Fixes ZEN-30308.